### PR TITLE
Fix: Correct ImportError for calculate_uncertainty in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ from app.rf_model import RFModel, train_rf_model, evaluate_rf_model
 
 # Import utility functions
 from app.utils import (
-    calculate_utility, calculate_novelty, calculate_uncertainty,
+    calculate_utility, calculate_novelty, # calculate_uncertainty was removed
     set_seed, enforce_diversity, identify_pareto_front,
     balance_exploration_exploitation
 )


### PR DESCRIPTION
Removed the import of `calculate_uncertainty` from `app.utils` in `main.py` as this function was deleted during the utility and uncertainty function consolidation. This resolves the ImportError reported by the user.