### PR TITLE
Fix: Simplify ReduceLROnPlateau call for ProtoNet scheduler

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -252,8 +252,8 @@ def initialize_scheduler(optimizer, scheduler_type, **kwargs):
             threshold_mode=threshold_mode,
             cooldown=cooldown,
             min_lr=min_lr,
-            eps=eps,
-            verbose=verbose
+            eps=eps
+            # verbose argument removed for simplicity
         )
     
     elif scheduler_type == "StepLR":


### PR DESCRIPTION
Further attempt to resolve the TypeError during ProtoNet model training. Removed the `verbose` argument from the explicit call to `torch.optim.lr_scheduler.ReduceLROnPlateau` in
`app/utils.py:initialize_scheduler`.

This is to ensure maximum compatibility and rule out issues related to the `verbose` parameter in the specific execution environment. All other necessary parameters were already being explicitly passed and type-cast.